### PR TITLE
Food placement fix

### DIFF
--- a/src/state.h
+++ b/src/state.h
@@ -236,8 +236,8 @@ public:
 
     // figure out if juniper is on left or right side of screen,
     // spawn food on opposite side, walk toward it then eat
-    bool right = (_position->x)
-                 > TamaConstant::SCREEN_WIDTH / 2.0f;
+    bool right = _position->x
+                 > (TamaConstant::SCREEN_WIDTH / 2.0f);
 
     float foodx;
     // spawn food on the opposite side of the screen, if juniper


### PR DESCRIPTION
The calculation to decide where to place the food has been updated to consider only the width of the screen in which juniper resides instead of the window width or taking into account the tama size.

This fixes an issue where food was always placed to the right of juniper no matter how far right juniper was.

Current behavior demo:
![just-juniper_hQHHdfH8tt](https://github.com/user-attachments/assets/e58e1ce4-eebc-4156-8de5-3836e8b0defd)

Fixed demo:
![just-juniper_hbyxLTT4ir](https://github.com/user-attachments/assets/ddfd528c-e259-4e8d-864b-fdaf7201abc6)
